### PR TITLE
Update identity integration with merged person details

### DIFF
--- a/internal/admina/client.go
+++ b/internal/admina/client.go
@@ -160,6 +160,12 @@ type Identity struct {
 	EmployeeStatus  string   `json:"employeeStatus"`
 	Email           string   `json:"primaryEmail"`
 	SecondaryEmails []string `json:"secondaryEmails"`
+	MergedPeople    []struct {
+		ID          int    `json:"id"`
+		DisplayName string `json:"displayName"`
+		PrimaryEmail string `json:"primaryEmail"`
+		Username    string `json:"username"`
+	} `json:"mergedPeople,omitempty"`
 }
 
 func (c *Client) GetIdentities(ctx context.Context, cursor string) ([]Identity, string, error) {
@@ -237,10 +243,21 @@ func (c *Client) MergeIdentities(ctx context.Context, fromPeopleID, toPeopleID i
 		return MergeIdentity{}, err
 	}
 
-	var response []MergeIdentity
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		if err == io.EOF {
-			c.debugLog("Received EOF response, assuming merge success")
+	// レスポンスボディをバッファに読み込む
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return MergeIdentity{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// RAWデータをログ出力
+	c.debugLog("Raw Response Body: %s", string(bodyBytes))
+
+	// APIからのレスポンス形式に合わせて構造体を定義
+	var response APIResponse[[]Identity]
+
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		if len(bodyBytes) == 0 || string(bodyBytes) == "{}" || string(bodyBytes) == "[]" {
+			c.debugLog("Received empty response, assuming merge success")
 			return MergeIdentity{
 				FromPeopleID: fromPeopleID,
 				ToPeopleID:   toPeopleID,
@@ -249,15 +266,37 @@ func (c *Client) MergeIdentities(ctx context.Context, fromPeopleID, toPeopleID i
 		return MergeIdentity{}, fmt.Errorf("failed to decode merge result: %w", err)
 	}
 
-	if len(response) == 0 {
-		c.debugLog("Received empty response, assuming merge success")
+	// レスポンスからマージされた情報を抽出
+	if len(response.Items) == 0 {
+		c.debugLog("Received empty items array, assuming merge success")
 		return MergeIdentity{
 			FromPeopleID: fromPeopleID,
 			ToPeopleID:   toPeopleID,
 		}, nil
 	}
 
-	return response[0], nil
+	// toPeopleID に該当するアイテムを探す
+	for _, item := range response.Items {
+		if item.PeopleID == toPeopleID {
+			// マージされたアイテムが見つかった
+			// mergedPeople 配列から fromPeopleID に該当する情報を確認
+			for _, mergedPerson := range item.MergedPeople {
+				if mergedPerson.ID == fromPeopleID {
+					return MergeIdentity{
+						FromPeopleID: fromPeopleID,
+						ToPeopleID:   toPeopleID,
+					}, nil
+				}
+			}
+		}
+	}
+
+	// 該当するマージ情報が見つからない場合（通常はここに来ないはず）
+	c.debugLog("Could not find merged identity in response, assuming success based on request")
+	return MergeIdentity{
+		FromPeopleID: fromPeopleID,
+		ToPeopleID:   toPeopleID,
+	}, nil
 }
 
 // Organization関連の構造体と関数

--- a/internal/admina/client.go
+++ b/internal/admina/client.go
@@ -161,10 +161,10 @@ type Identity struct {
 	Email           string   `json:"primaryEmail"`
 	SecondaryEmails []string `json:"secondaryEmails"`
 	MergedPeople    []struct {
-		ID          int    `json:"id"`
-		DisplayName string `json:"displayName"`
+		ID           int    `json:"id"`
+		DisplayName  string `json:"displayName"`
 		PrimaryEmail string `json:"primaryEmail"`
-		Username    string `json:"username"`
+		Username     string `json:"username"`
 	} `json:"mergedPeople,omitempty"`
 }
 

--- a/internal/admina/client_test.go
+++ b/internal/admina/client_test.go
@@ -41,9 +41,9 @@ func setupTestServer() (*httptest.Server, *Client) {
 			json.NewEncoder(w).Encode(response)
 		case "/api/v1/organizations/test-org/identity/merge":
 			// Revert to using Raw JSON String for the mock response
-			rawJsonResponse := `{
+			rawJSONResponse := `{
 				"meta": {
-					"next_cursor": ""
+					"next_cursor": "next"
 				},
 				"items": [
 					{
@@ -68,7 +68,7 @@ func setupTestServer() (*httptest.Server, *Client) {
 				"dummy_feature_field": "dummy_feature_value"
 			}`
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(rawJsonResponse))
+			w.Write([]byte(rawJSONResponse))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/admina/client_test.go
+++ b/internal/admina/client_test.go
@@ -40,10 +40,30 @@ func setupTestServer() (*httptest.Server, *Client) {
 			}
 			json.NewEncoder(w).Encode(response)
 		case "/api/v1/organizations/test-org/identity/merge":
-			response := []MergeIdentity{
-				{
-					FromPeopleID: 1,
-					ToPeopleID:   2,
+			response := APIResponse[[]Identity]{
+				Meta: Meta{
+					NextCursor: "",
+				},
+				Items: []Identity{
+					{
+						ID:          "1",
+						PeopleID:    2,
+						DisplayName: "Test User",
+						Email:       "test@example.com",
+						MergedPeople: []struct {
+							ID          int    `json:"id"`
+							DisplayName string `json:"displayName"`
+							PrimaryEmail string `json:"primaryEmail"`
+							Username    string `json:"username"`
+						}{
+							{
+								ID:          1,
+								DisplayName: "",
+								PrimaryEmail: "from@example.com",
+								Username:    "",
+							},
+						},
+					},
 				},
 			}
 			json.NewEncoder(w).Encode(response)

--- a/internal/admina/client_test.go
+++ b/internal/admina/client_test.go
@@ -40,33 +40,35 @@ func setupTestServer() (*httptest.Server, *Client) {
 			}
 			json.NewEncoder(w).Encode(response)
 		case "/api/v1/organizations/test-org/identity/merge":
-			response := APIResponse[[]Identity]{
-				Meta: Meta{
-					NextCursor: "",
+			// Revert to using Raw JSON String for the mock response
+			rawJsonResponse := `{
+				"meta": {
+					"next_cursor": ""
 				},
-				Items: []Identity{
+				"items": [
 					{
-						ID:          "1",
-						PeopleID:    2,
-						DisplayName: "Test User",
-						Email:       "test@example.com",
-						MergedPeople: []struct {
-							ID          int    `json:"id"`
-							DisplayName string `json:"displayName"`
-							PrimaryEmail string `json:"primaryEmail"`
-							Username    string `json:"username"`
-						}{
+						"id": "1",
+						"peopleId": 2,
+						"displayName": "Test User",
+						"primaryEmail": "test@example.com",
+						"secondaryEmails": [],
+						"managementType": "managed",
+						"employeeType": "full_time_employee",
+						"employeeStatus": "active",
+						"mergedPeople": [
 							{
-								ID:          1,
-								DisplayName: "",
-								PrimaryEmail: "from@example.com",
-								Username:    "",
-							},
-						},
-					},
-				},
-			}
-			json.NewEncoder(w).Encode(response)
+								"id": 1,
+								"displayName": "",
+								"primaryEmail": "from@example.com",
+								"username": ""
+							}
+						]
+					}
+				],
+				"dummy_feature_field": "dummy_feature_value"
+			}`
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(rawJsonResponse))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/internal/identity/identity_merge.go
+++ b/internal/identity/identity_merge.go
@@ -138,7 +138,7 @@ func processSingleCandidate(ctx context.Context, client Client, config *MergeCon
 		return "Error", err
 	}
 
-	logger.LogInfo("Successfully merged %d -> %d", clientMergeResult.FromPeopleID, clientMergeResult.ToPeopleID)
+	logger.LogInfo("Successfully merged %s (%d) -> %s (%d)", MaskEmail(candidate.Child.Email), clientMergeResult.FromPeopleID, MaskEmail(candidate.Parent.Email), clientMergeResult.ToPeopleID)
 	candidate.Status = "Success"
 	return "Success", nil
 }
@@ -162,8 +162,8 @@ func outputResults(result *MergeResult, config *MergeConfig, mergedCount, skippe
 		return fmt.Errorf("failed to format output: %v", err)
 	}
 
-	logger.LogInfo("Outputting merge results")
-	logger.LogInfo("%s", output)
+	// JSONフォーマッタの場合、ログレベルをDEBUGに変更
+	logger.LogDebug("%s", output)
 
 	// CSVファイルの出力処理
 	outputDir := config.getOutputDir()


### PR DESCRIPTION
マージされたアイデンティティの詳細を含むようにアイデンティティ統合機能を強化し、APIレスポンスフォーマットを更新し、APIの仕様に合わせてモックレスポンスを調整する。