### PR TITLE
Feat/00 minimum release age

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
           go-version: "1.23"
       - name: Set up Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: Install dependencies
         run: make deps
       - name: Run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: make deps
       - name: Run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: Run tests
         env:
           ADMINA_ORGANIZATION_ID: "dummy_organization_id"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - name: Upgrade npm
+        run: npm install -g npm@latest
       - name: Run tests
         env:
           ADMINA_ORGANIZATION_ID: "dummy_organization_id"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "npm": ">=11.10.0"
+  },
   "dependencies": {
     "xunit-viewer": "^10.6.1"
   }


### PR DESCRIPTION
We're adding a minimum age of packages of 7 days in order to mitigate potential supply chain attacks. This works in combination with Takumi Guard which has been added in earlier changes.